### PR TITLE
Fix a command line in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,6 @@ compile rutime to run mruby on host, and make a mruby kernel module.
 
 ## Run
 
-    sudo insmod kernel/mruby.ko        # load the mruby kernel module
-    sudo cat hello.mrb > /proc/mruby   # load and execute the mruby bytecode
-    dmesg                              # check the output
+    sudo insmod kernel/mruby.ko                # load the mruby kernel module
+    sudo sh -c 'cat hello.mrb > /proc/mruby'   # load and execute the mruby bytecode
+    dmesg                                      # check the output


### PR DESCRIPTION

The stdout redirection in the following command line will be outside the scope of root privilege:

    sudo cat hello.mrb > /proc/mruby

So it should be specified with the shell command like below:

    sudo sh -c 'cat hello.mrb > /proc/mruby'